### PR TITLE
Updated links in CrateDB Cloud Howtos post-migration

### DIFF
--- a/docs/add-users.rst
+++ b/docs/add-users.rst
@@ -94,4 +94,4 @@ Restrictions
   they will still have administrative rights in that project.
 
 
-.. _role: https://crate.io/docs/cloud-console/docs/user-roles.rst
+.. _role: https://crate.io/docs/cloud/reference/en/latest/user-roles.html

--- a/docs/create-org.rst
+++ b/docs/create-org.rst
@@ -87,7 +87,7 @@ provide a valid notification email, CrateDB Cloud will send relevant
 operational notifications via email to that address.
 
 
-.. _guide on creating a new project: https://crate.io/docs/cloud-console/docs/create-project.rst
-.. _guide to adding users to organizations and projects: https://crate.io/docs/cloud-console/docs/add-users.rst
-.. _guide to creating projects: https://crate.io/docs/cloud-console/docs/create-project.rst
-.. _guide to user roles in CrateDB Cloud: https://crate.io/docs/cloud-console/docs/user-roles.rst
+.. _guide on creating a new project: https://crate.io/docs/cloud/howtos/en/latest/create-project.html
+.. _guide to adding users to organizations and projects: https://crate.io/docs/cloud/howtos/en/latest/add-users.html
+.. _guide to creating projects: https://crate.io/docs/cloud/howtos/en/latest/create-project.html
+.. _guide to user roles in CrateDB Cloud: https://crate.io/docs/cloud/reference/en/latest/user-roles.html

--- a/docs/create-project.rst
+++ b/docs/create-project.rst
@@ -87,6 +87,6 @@ A project can be deleted in the Project Settings page by clicking the *Delete*
 button at the top right.
 
 
-.. _guide on how to deploy a cluster via the Azure Marketplace: https://help.crate.io/en/articles/3603380-how-to-deploy-a-cluster-via-the-azure-marketplace
-.. _guide on user roles in CrateDB Cloud: https://crate.io/docs/cloud-console/docs/user-roles.rst
-.. _guide to adding users to organizations and projects: https://crate.io/docs/cloud-console/docs/add-users.rst
+.. _guide on how to deploy a cluster via the Azure Marketplace: https://crate.io/docs/cloud/tutorials/en/latest/getting-started/azure-to-cluster/index.html
+.. _guide on user roles in CrateDB Cloud: https://crate.io/docs/cloud/reference/en/latest/user-roles.html
+.. _guide to adding users to organizations and projects: https://crate.io/docs/cloud/howtos/en/latest/add-users.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,5 +41,5 @@ Documentation for `Croud`_, the CLI for CrateDB Cloud.
 
 
 .. _Croud: https://crate.io/docs/cloud/cli/en/latest/
-.. _Tutorials: https://crate.io/docs/cloud/tutorials/
+.. _Tutorials: https://crate.io/docs/cloud/tutorials/en/latest/
 .. _GitHub: https://github.com/crate/cloud-howtos/

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -23,7 +23,7 @@ Basics
 
 .. image:: _assets/img/start.png
 
-You must access the Cloud Console by `region`_.
+You must access the Cloud Console by |region|.
 
 Available regions:
 
@@ -37,7 +37,7 @@ Available regions:
 | Bregenz           | `bregenz.a1.cratedb.cloud`_       |
 +-------------------+-----------------------------------+
 
-Azure East-US2 and Azure West-Europe are managed by `Microsoft Azure`_. The
+Azure East-US2 and Azure West-Europe are managed by |Microsoft Azure|. The
 Bregenz region is managed by Crate.io and is located in Austria.
 
 Azure East-US2 is a good default region if you don't know which one to pick.
@@ -60,7 +60,7 @@ Account overview
 The account overview screen lists the organizations and projects you can
 access.
 
-If you follow the `getting started`_ instructions and deploy a test cluster,
+If you follow the `tutorial`_ instructions and deploy a test cluster,
 your account overview will look something like this:
 
 .. image:: _assets/img/account-overview.png
@@ -249,9 +249,15 @@ With the *Delete* button, you can delete the current cluster.
 .. _bregenz.a1.cratedb.cloud: https://bregenz.a1.cratedb.cloud/
 .. _CrateDB Cloud: https://crate.io/products/cratedb-cloud/
 .. _eastus2.azure.cratedb.cloud: https://eastus2.azure.cratedb.cloud/
-.. _getting started: https://crate.io/docs/cloud/getting-started/
 .. _HTTP: https://crate.io/docs/crate/reference/en/latest/interfaces/http.html
-.. _Microsoft Azure: https://azure.microsoft.com/en-us/
 .. _PostgreSQL wire protocol: https://crate.io/docs/crate/reference/en/latest/interfaces/postgres.html
-.. _region: https://azure.microsoft.com/en-us/global-infrastructure/regions/
+.. _tutorial: https://crate.io/docs/cloud/tutorials/en/latest/getting-started/index.html
 .. _westeurope.azure.cratedb.cloud: https://westeurope.azure.cratedb.cloud/
+
+.. |Microsoft Azure| raw:: html
+
+    <a href="https://azure.microsoft.com/" target="_blank">Microsoft Azure</a>
+
+.. |region| raw:: html
+
+    <a href="https://azure.microsoft.com/en-us/global-infrastructure/regions/" target="_blank">region</a>

--- a/docs/scale-cluster.rst
+++ b/docs/scale-cluster.rst
@@ -92,4 +92,4 @@ When scaling a cluster, there are some important aspects to keep in mind:
 
 
 .. _Crate DB Documentation: https://crate.io/docs/crate/reference/en/latest/general/ddl/replication.html
-.. _guide on how to deploy a cluster via the Microsoft Azure Marketplace for the first time: https://help.crate.io/en/articles/3603380-how-to-deploy-a-cluster-via-the-azure-marketplace
+.. _guide on how to deploy a cluster via the Microsoft Azure Marketplace for the first time: https://crate.io/docs/cloud/tutorials/en/latest/getting-started/azure-to-cluster/index.html


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
This fixes links that have expired due to the change in Docs naming. It also creates HTML link entries so Azure links, as a link to a third party controlled site, open in a new tab.

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
