### PR TITLE
Fixing capitalization of internal docs names

### DIFF
--- a/docs/add-users.rst
+++ b/docs/add-users.rst
@@ -30,7 +30,7 @@ Add users to an organization
 
 New users can be added to an organization by going to the Organization page in
 the Console if you are logged in as organization admin. (For more information
-on user roles and associated privileges, see our Documentation on
+on user roles and associated privileges, see our documentation on
 `user roles`_.) At the top, you will see three tabs labelled *Settings*,
 *Users*, and *Audit Log*.
 

--- a/docs/create-project.rst
+++ b/docs/create-project.rst
@@ -52,7 +52,7 @@ click on that project there to select it. Below the divider line on the
 left-hand menu, the tabs for *Overview*, *Users* and *Settings* will now refer
 to the selected project. For more information on how to interact with the
 project through these pages, see their description in the `Console overview`_
-in our Documentation.
+in our documentation.
 
 
 .. _Console overview: https://crate.io/docs/cloud/howtos/en/latest/overview.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ these guides, we assume you interact with CrateDB Cloud by using the CrateDB
 Cloud Console. This is the hosted user interface designed to make interacting
 with CrateDB Cloud easier and more accessible, without the need for a command
 line interface (CLI). If you do wish to use the CLI instead, see the
-Documentation for `Croud`_, the CLI for CrateDB Cloud.
+documentation for `Croud`_, the CLI for CrateDB Cloud.
 
 .. NOTE::
 
@@ -20,7 +20,7 @@ Documentation for `Croud`_, the CLI for CrateDB Cloud.
 .. NOTE::
 
     This resource assumes you know the basics. If not, check out the
-    `Tutorials`_ section for beginner material.
+    `tutorials`_ section for beginner material.
 
 .. SEEALSO::
 
@@ -41,5 +41,5 @@ Documentation for `Croud`_, the CLI for CrateDB Cloud.
 
 
 .. _Croud: https://crate.io/docs/cloud/cli/en/latest/
-.. _Tutorials: https://crate.io/docs/cloud/tutorials/en/latest/
+.. _tutorials: https://crate.io/docs/cloud/tutorials/en/latest/
 .. _GitHub: https://github.com/crate/cloud-howtos/

--- a/docs/scale-cluster.rst
+++ b/docs/scale-cluster.rst
@@ -94,8 +94,8 @@ When scaling a cluster, there are some important aspects to keep in mind:
   adjusted. This occurs when the desired number of nodes in your cluster is
   lower than the number of copies of a given table (this is the number of
   replicas + 1). For reference on how to do this, see the `CrateDB
-  Documentation`_.
+  documentation`_.
 
 
-.. _CrateDB   Documentation: https://crate.io/docs/crate/reference/en/latest/general/ddl/replication.html
+.. _CrateDB   documentation: https://crate.io/docs/crate/reference/en/latest/general/ddl/replication.html
 .. _guide on how to deploy a cluster via the Microsoft Azure Marketplace for the first time: https://crate.io/docs/cloud/tutorials/en/latest/getting-started/azure-to-cluster/index.html

--- a/docs/snapshot.rst
+++ b/docs/snapshot.rst
@@ -7,7 +7,7 @@ Restore backups and snapshots
 This short guide explains in general terms the CrateDB Cloud backup policy for
 automatically generating snapshots of the cluster data and how one can use such
 snapshots to restore data. A more detailed technical discussion of how CrateDB
-handles snapshots can be found in the `CrateDB Documentation`_.
+handles snapshots can be found in the `CrateDB documentation`_.
 
 .. rubric:: Table of contents
 
@@ -55,10 +55,10 @@ that snapshot was created.
 
 You can restore a snapshot in two ways. One option is to `contact CrateDB Cloud
 support`_. We are happy to assist. Alternatively, you can use the CrateDB Admin
-UI to do it yourself. Please refer to the `Reference`_ in the documentation for
+UI to do it yourself. Please refer to the `reference`_ in the documentation for
 assistance.
 
 
 .. _contact CrateDB Cloud support: https://help.crate.io/en/
-.. _CrateDB Documentation: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
-.. _Reference: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html#restore
+.. _CrateDB documentation: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
+.. _reference: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html#restore


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Fixes the capitalization of internal references to documentation (and docs headers), as per tech writing discussion

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
