### PR TITLE
Copyedit: add alt text to images in Cloud docs (Howtos)

### DIFF
--- a/docs/add-users.rst
+++ b/docs/add-users.rst
@@ -35,6 +35,7 @@ roles`_.) At the top, you will see four tabs labelled *Subscriptions*,
 *Settings*, *Users*, and *Audit Log*.
 
 .. image:: _assets/img/organization-overview.png
+   :alt: Cloud Console organization overview
 
 Click the *Users* tab to see an overview of all users associated with the
 organization. It will show their username, email, and user role.
@@ -42,6 +43,7 @@ organization. It will show their username, email, and user role.
 To add a new user click the *Add user* button in the top right.
 
 .. image:: _assets/img/organization-users.png
+   :alt: Cloud Console organization overview users tab
 
 First, enter the email address the user signed up with.
 
@@ -50,6 +52,7 @@ Second, select the `role`_ you want to give the user in your organization.
 Finally, click *Save*.
 
 .. image:: _assets/img/organization-users-dropdown.png
+   :alt: Cloud Console org add user dropdown menu
 
 
 .. _add-users-edit:
@@ -79,6 +82,7 @@ projects created within the organization on this page, with name, timestamp of
 creation, project ID, and region of deployment.
 
 .. image:: _assets/img/projects.png
+   :alt: Cloud Console projects overview
 
 Click on the project you want to add users to to select it. Below the divider
 line in the left-hand menu are shown the project-specific options. Go to the
@@ -86,11 +90,13 @@ line in the left-hand menu are shown the project-specific options. Go to the
 associated with the project, as well as their email address and role.
 
 .. image:: _assets/img/project-users.png
+   :alt: Cloud Console users overview
 
 To add a user, click the *Add user* button at the top right. Choose a user and
 the project role you want them to have.
 
 .. image:: _assets/img/project-users-dropdown.png
+   :alt: Cloud Console project add user dropdown menu
 
 Finally, click *Save* to add the user.
 

--- a/docs/create-org.rst
+++ b/docs/create-org.rst
@@ -27,6 +27,7 @@ Organization overview page. If there is not currently an active organization,
 the page will display an empty box logo and the message *No organization yet*.
 
 .. image:: _assets/img/create-org.png
+   :alt: Cloud Console org overview without organization
 
 In order to create an organization, fill out the organization name in the space
 provided, and click *Create organization*.
@@ -45,6 +46,7 @@ left-hand menu in the Console. Here you will see an overview of your
 organization, further subscription options, and any deployed clusters.
 
 .. image:: _assets/img/organization-overview.png
+   :alt: Cloud Console organization overview
 
 The current tab is by default *Subscriptions*. There are also three further
 tabs.

--- a/docs/create-project.rst
+++ b/docs/create-project.rst
@@ -22,6 +22,7 @@ Organization overview page. This page displays your organization with the name
 you selected, further subscription options, and any deployed clusters.
 
 .. image:: _assets/img/organization-overview.png
+   :alt: Cloud Console organization overview
 
 In order to create a new project within the organization, click on the
 *Projects* tab in the left-hand menu to go to the Projects page.
@@ -37,12 +38,14 @@ It will show their name, timestamp of creation, project ID, and region of
 deployment.
 
 .. image:: _assets/img/projects.png
+   :alt: Cloud Console projects overview
 
 Here, you can create a new project. To do so, click the *Create Project* button
 at the top right. It will prompt you for a project name and a region you want
 the project to be based in.
 
 .. image:: _assets/img/projects-newproject.png
+   :alt: Cloud Console add project dropdown menu
 
 Fill out the desired information and confirm by clicking *Create* at the bottom
 right corner.

--- a/docs/delete-cluster.rst
+++ b/docs/delete-cluster.rst
@@ -56,6 +56,7 @@ an overview of all projects. (If you followed the previous tutorial, there
 should be just one.)
 
 .. image:: _assets/img/projects.png
+   :alt: Cloud Console projects overview
 
 Select the relevant project by clicking on it. Make sure the correct region is
 displayed in the regions dropdown menu to see the correct project, or select
@@ -69,6 +70,7 @@ the one we want. Clicking this will lead to the Cluster Settings page for the
 cluster.
 
 .. image:: _assets/img/cluster-settings.png
+   :alt: Cloud Console cluster settings
 
 On this page, you will see size and scaling information for the cluster in
 question. You can delete the cluster here as well. Simply click the bin icon at
@@ -98,17 +100,20 @@ resources, services, and docs*) and enter "SaaS" there. The SaaS item should
 then appear in the list of results.
 
 .. image:: _assets/img/azureservices.png
+   :alt: Azure Portal services menu
 
 Click on this icon. If you have subscribed to the CrateDB Cloud offer and have
 deployed a cluster previously, the cluster name should now appear in the list
 of SaaS items.
 
 .. image:: _assets/img/azuresaas.png
+   :alt: Azure Portal SaaS subscriptions list
 
 All that remains is to click directly on the relevant cluster name (you do not
 need to tick the box). This will take you to a screen with cluster details.
 
 .. image:: _assets/img/azuresaasdetails.png
+   :alt: Azure Portal SaaS cluster details
 
 To delete the cluster, press the *Delete* button at the top right and confirm.
 
@@ -137,17 +142,20 @@ On the landing page, find your account name in the top right corner, and in the
 dropdown menu, select *Your Marketplace Software*.
 
 .. image:: _assets/img/aws-marketplace.png
+   :alt: AWS Marketplace landing page
 
 This will take you to an overview of your AWS Marketplace subscriptions. You
 should see CrateDB Cloud there. Each subscription item has a button labelled
 *Manage*. Click this button for CrateDB Cloud.
 
 .. image:: _assets/img/aws-subscriptions.png
+   :alt: AWS Marketplace subscription management page
 
 You will now see a page with the CrateDB Cloud "pay as you go" offer on it. At
 the top right corner there is a button labelled *Actions*.
 
 .. image:: _assets/img/aws-cratedbcloud.png
+   :alt: AWS Marketplace subscription CrateDB Cloud
 
 This generates a drop-down menu with various options for interacting with the
 offer. In this menu, click the option *Cancel subscription*.

--- a/docs/scale-cluster.rst
+++ b/docs/scale-cluster.rst
@@ -32,6 +32,7 @@ To scale your clusters in the Console, you must find the Cluster Settings page.
 When you first access the Console, you will arrive at the Organization page.
 
 .. image:: _assets/img/organization-overview.png
+   :alt: Cloud Console organization overview
 
 To scale a cluster, you need to know what project the cluster belongs to. Go to
 the Projects page in the left-hand menu to find an overview of all projects
@@ -45,6 +46,7 @@ Here, find the correct cluster and click on the icon. It will expand and show
 links for three pages: *Overview*, *Metrics* and *Settings*.
 
 .. image:: _assets/img/cluster-dropdown.png
+   :alt: Cloud Console projects cluster selection
 
 Click on *Settings*. This will take you to the Cluster Settings page, where
 you can see the current scale unit of the cluster, as well as an information
@@ -53,6 +55,7 @@ within the permitted range, simply click the *Edit scale unit* button at the
 top right.
 
 .. image:: _assets/img/cluster-settings.png
+   :alt: Cloud Console cluster settings
 
 
 .. _scale-cluster-instructions:
@@ -70,6 +73,7 @@ appears.
 Finally, confirm with *Save*.
 
 .. image:: _assets/img/cluster-scale-dropdown.png
+   :alt: Cloud Console cluster settings scaling menu
 
 The values corresponding to each scale unit will vary depending on the plan
 selected for the cluster. This also affects the cluster configuration and

--- a/docs/snapshot.rst
+++ b/docs/snapshot.rst
@@ -20,8 +20,7 @@ handles snapshots can be found in the `CrateDB documentation`_.
 CrateDB Cloud's backup policy
 =============================
 
-CrateDB Cloud takes *hourly snapshots* which are kept for *14 days*. After that
-time snapshots will be deleted.
+CrateDB Cloud takes *hourly snapshots* which are kept for *14 days*.
 
 
 .. _snapshot-restore:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Adds alt text for all images in this docs section, providing greater accessibility
- Resolves [this issue](https://github.com/crate/tech-writing-domain/issues/376) as well as [this issue](https://github.com/crate/cloud-howtos/issues/43)

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
