### PR TITLE
Fix to Cloud Howtos ToC

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,7 @@ documentation for `Croud`_, the CLI for CrateDB Cloud.
 .. rubric:: Table of contents
 
 .. toctree::
+    :maxdepth: 2
     :titlesonly:
 
     create-org


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Fixes the left-hand menu overview of the Cloud Howtos - these were not showing the subdirectories

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
