### PR TITLE
Fix merger process after strict merge deprecation

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,14 +1,21 @@
 ---
+queue_rules:
+  - name: default
+    conditions:
+      - check-success~=^Build docs on ubuntu-latest
+      - check-success~=^Build docs on macos-latest
+      - check-success~=docs/readthedocs.org
+
 pull_request_rules:
-  - actions:
-      merge:
-        method: rebase
-        rebase_fallback: null
-        strict: true
+  - name: automatic merge
     conditions:
       - label=ready-to-merge
       - '#approved-reviews-by>=1'
-      - status-success~=Build docs on ubuntu-latest
-      - status-success~=Build docs on macos-latest
+      - status-success~=^Build docs on ubuntu-latest
+      - status-success~=^Build docs on macos-latest
       - status-success~=docs/readthedocs.org
-    name: default
+    actions:
+      queue:
+        method: rebase
+        name: default
+        rebase_fallback: none


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Fixes mergify.yml, which relies on a deprecated merger method, so that PRs can pass again

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
