### PR TITLE
mergify: Remove deprecated rebase_fallback option

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,4 +18,3 @@ pull_request_rules:
       queue:
         method: rebase
         name: default
-        rebase_fallback: none


### PR DESCRIPTION
The configuration uses the deprecated rebase_fallback attribute of the queue action. 
Confirmed in https://github.com/crate/crate/pull/13484
## Summary of the changes / Why this is an improvement


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
